### PR TITLE
Achieve compatibility with ppxlib 0.22.0

### DIFF
--- a/base_quickcheck.opam
+++ b/base_quickcheck.opam
@@ -20,7 +20,7 @@ depends: [
   "ppx_sexp_value"    {>= "v0.14" & < "v0.15"}
   "splittable_random" {>= "v0.14" & < "v0.15"}
   "dune"              {>= "2.0.0"}
-  "ppxlib"            {>= "0.11.0"}
+  "ppxlib"            {>= "0.22.0"}
 ]
 synopsis: "Randomized testing framework, designed for compatibility with Base"
 description: "

--- a/ppx_quickcheck/expander/environment.mli
+++ b/ppx_quickcheck/expander/environment.mli
@@ -10,7 +10,7 @@ val lookup : t -> loc:location -> tyvar:string -> expression
 val create
   :  loc:location
   -> prefix:string
-  -> (core_type * variance) list
+  -> (core_type * (variance * injectivity)) list
   -> pattern list * t
 
 (** For generators, we want contravariant type parameters to map to observer names. For
@@ -19,5 +19,5 @@ val create_with_variance
   :  loc:location
   -> covariant:string
   -> contravariant:string
-  -> (core_type * variance) list
+  -> (core_type * (variance * injectivity)) list
   -> pattern list * [ `Covariant of t ] * [ `Contravariant of t ]

--- a/ppx_quickcheck/expander/ppx_quickcheck_expander.ml
+++ b/ppx_quickcheck/expander/ppx_quickcheck_expander.ml
@@ -347,11 +347,12 @@ let intf type_decl ~f ~covar ~contravar =
     List.fold_right
       type_decl.ptype_params
       ~init:result
-      ~f:(fun (core_type, variance) result ->
+      ~f:(fun (core_type, (variance, injectivity)) result ->
         let id =
-          match variance with
-          | Invariant | Covariant -> covar
-          | Contravariant -> contravar
+          match (variance, injectivity) with
+          | ((NoVariance | Covariant), NoInjectivity) -> covar
+          | (Contravariant, NoInjectivity) -> contravar
+          | (_, Injective) -> Location.raise_errorf ~loc "Injective type parameters aren't supported."
         in
         let arg = ptyp_constr ~loc { loc; txt = id } [ core_type ] in
         [%type: [%t arg] -> [%t result]])


### PR DESCRIPTION
In ppxlib 0.22.0, the AST gets bumped to ocaml 4.12. This commit adapts to the compiler changes from 4.11 to 4.12: mainly, the introduction of injectivity to type declarations.

Note: the commit only guaranties compatibility. It doesn't add support for the new `Injective` feature and raises when used.

It would be good to merge this PR when ppxlib 0.22.0 gets released, which will be soon.

cc @NathanReb